### PR TITLE
Update deprecated setupTestFrameworkScriptFile.

### DIFF
--- a/7-testing/7.3-enzyme-testing.md
+++ b/7-testing/7.3-enzyme-testing.md
@@ -25,7 +25,7 @@ The default react-native boilerplate comes with Jest. Integrating Enzyme with Je
       ...,
       "jest": {
         ...,
-        "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js",
+        "setupFilesAfterEnv": ["./node_modules/jest-enzyme/lib/index.js"],
         "setupFiles": ["enzyme-react-16-adapter-setup"]
       }
     }


### PR DESCRIPTION
Update enzyme configuration in Jest.
`setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`.

[As described in Jest docs](https://jestjs.io/docs/en/configuration#setupfilesafterenv-array)